### PR TITLE
Fix subscription mutex contention and ZGT resub storms

### DIFF
--- a/Apps/SonosAdvancedApp.groovy
+++ b/Apps/SonosAdvancedApp.groovy
@@ -2742,12 +2742,12 @@ void executeLocalControlRetry() {
 
 Boolean shouldRequestZgtResub(String dni) {
   if(dni == null || dni == '') { return false }
-  Long now = System.currentTimeMillis()
+  Long nowMs = now()
   Long previous = zgtResubRequestAt.get(dni)
-  if(previous != null && (now - previous) < ZGT_RESUB_REQUEST_MIN_INTERVAL_MS) {
+  if(previous != null && (nowMs - previous) < ZGT_RESUB_REQUEST_MIN_INTERVAL_MS) {
     return false
   }
-  zgtResubRequestAt.put(dni, now)
+  zgtResubRequestAt.put(dni, nowMs)
   return true
 }
 

--- a/Apps/SonosAdvancedApp.groovy
+++ b/Apps/SonosAdvancedApp.groovy
@@ -55,6 +55,11 @@ preferences {
 @Field static final String LOCAL_CONTROL_RETRY_STATE_KEY = 'localControlRetryAttemptCount'
 @Field static final String LOCAL_CONTROL_RETRY_REQUEST_STATE_KEY = 'lastLocalControlRetryRequest'
 @Field static final String LOCAL_CONTROL_RETRY_DATA_KEY = '_localControlRetryRequest'
+// Per-child debounce for GROUP_STATUS_MOVED driven ZGT resubscribes. Burst 499
+// responses during group transitions would otherwise fire dozens of subscribes
+// on the same device back to back.
+@Field static java.util.concurrent.ConcurrentHashMap<String, Long> zgtResubRequestAt = new java.util.concurrent.ConcurrentHashMap<String, Long>()
+@Field static final Long ZGT_RESUB_REQUEST_MIN_INTERVAL_MS = 60000L
 @Field static Map SOURCES = [
   "\$": "None",
   "x-file-cifs:": "Library",
@@ -2735,15 +2740,25 @@ void executeLocalControlRetry() {
   }
 }
 
+Boolean shouldRequestZgtResub(String dni) {
+  if(dni == null || dni == '') { return false }
+  Long now = System.currentTimeMillis()
+  Long previous = zgtResubRequestAt.get(dni)
+  if(previous != null && (now - previous) < ZGT_RESUB_REQUEST_MIN_INTERVAL_MS) {
+    return false
+  }
+  zgtResubRequestAt.put(dni, now)
+  return true
+}
+
 Boolean responseIsValid(AsyncResponse response, String requestName = null) {
   if(response?.status == 499) {
     try{
       Map errData = response.getErrorData()
       if(errData?.groupStatus == 'GROUP_STATUS_MOVED') {
         ChildDeviceWrapper child = getDeviceFromRincon(errData?.playerId)
-        if(child) {
-          child.subscribeToZgtEvents()
-          logDebug('Resubscribed to ZGT to handle "GROUP_STATUS_MOVED" errors')
+        if(child != null && shouldRequestZgtResub(child.getDeviceNetworkId())) {
+          child.requestZgtResub()
         }
       }
     } catch(Exception e){}

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -636,6 +636,9 @@ void cleanupStaticDriverState() {
     clearedEntries += clearStaticMap(jsonSlurpers)
     clearedEntries += clearStaticMap(eventTimestamps)
     clearedEntries += clearStaticMap(favPlaylistDelegate)
+    clearedEntries += clearStaticMap(subscribeMutexes)
+    clearedEntries += clearStaticMap(unsubscribeMutexes)
+    clearedEntries += clearStaticMap(subscribeRetryAttempts)
     if(clearedEntries > 0) {
       logDebug("Cleared ${clearedEntries} orphaned static Sonos Advanced Player cache entries with no active players present")
     }
@@ -668,6 +671,9 @@ void cleanupStaticDriverState() {
   removedEntries += pruneStaticMapKeys(jsonSlurpers, activePlayerDnis)
   removedEntries += pruneEventTimestampKeys(activePlayerDnis)
   removedEntries += pruneFavPlaylistDelegates(activePlayerDnis)
+  removedEntries += pruneDniPrefixedMap(subscribeMutexes, activePlayerDnis)
+  removedEntries += pruneDniPrefixedMap(unsubscribeMutexes, activePlayerDnis)
+  removedEntries += pruneDniPrefixedMap(subscribeRetryAttempts, activePlayerDnis)
 
   if(removedEntries > 0) {
     logDebug("Cleaned ${removedEntries} orphaned static Sonos Advanced Player cache entries")
@@ -733,6 +739,25 @@ Integer pruneFavPlaylistDelegates(Set<String> activePlayerDnis) {
   return removedEntries
 }
 
+// Prune keys from a static map whose leading segment (before the first '-')
+// isn't an active DNI. Used for the per-device subscription/retry maps whose
+// keys are either "${dni}" or "${dni}-${suffix}". Safe assumption: Sonos
+// DNIs are RINCON_XXXX style with no '-' characters.
+@CompileStatic
+Integer pruneDniPrefixedMap(ConcurrentHashMap map, Set<String> activeDnis) {
+  if(map == null || map.isEmpty() || activeDnis == null || activeDnis.isEmpty()) { return 0 }
+  Integer removed = 0
+  List<String> keys = new ArrayList<String>(map.keySet())
+  keys.each { String key ->
+    Integer idx = key.indexOf('-')
+    String dni = idx < 0 ? key : key.substring(0, idx)
+    if(!activeDnis.contains(dni)) {
+      if(map.remove(key) != null) { removed++ }
+    }
+  }
+  return removed
+}
+
 @CompileStatic
 String extractKeyPrefix(String key, String delimiter) {
   if(key == null || delimiter == null) { return null }
@@ -790,6 +815,9 @@ void clearStaticDriverStateForCurrentDevice() {
       jsonSlurpers?.remove(dni)
       wsSubscriptionStatus?.keySet()?.removeAll { String key -> key.startsWith("${dni}-WS-") }
       eventTimestamps?.keySet()?.removeAll { String key -> key.startsWith("${dni}-") }
+      unsubscribeMutexes?.remove(dni)
+      subscribeMutexes?.keySet()?.removeAll { String key -> key.startsWith("${dni}-") }
+      subscribeRetryAttempts?.keySet()?.removeAll { String key -> key.startsWith("${dni}-") }
     }
 
     releaseFavPlaylistDelegate()

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -945,7 +945,7 @@ BigDecimal coerceVolume(Object volume) {
       return null
     }
   }
-  logWarn("Unsupported volume type; ignoring.")
+  logWarn("Unsupported volume value '${volume}'; ignoring.")
   return null
 }
 

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -917,7 +917,7 @@ BigDecimal coerceVolume(Object volume) {
       return null
     }
   }
-  logWarn("Unsupported volume type ${volume.getClass().getName()}; ignoring.")
+  logWarn("Unsupported volume type; ignoring.")
   return null
 }
 

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -2972,7 +2972,7 @@ void subscribeResubscribeGenericCallback(String sub, String resub, String subId,
       updateSid(subId, response.headers)
       // Cancel any retries queued by prior "attempt in progress" fallbacks so
       // they don't keep firing now that we have a valid subscription.
-      unschedule(sub)
+      removeResub(sub)
       clearSubscriptionRetryAttempts(sub)
       clearSubscriptionRetryAttempts(resub)
       scheduleResubscriptionToEvents(resub)

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -277,15 +277,18 @@ import java.util.concurrent.TimeUnit
 @Field static ConcurrentHashMap<String, ConcurrentLinkedQueue<Map>> audioClipQueueHighPriority = new ConcurrentHashMap<String, ConcurrentLinkedQueue<Map>>()
 @Field static ConcurrentHashMap<String, ConcurrentLinkedQueue<Map>> audioClipQueueSaved = new ConcurrentHashMap<String, ConcurrentLinkedQueue<Map>>()
 @Field static ConcurrentHashMap<String, LinkedHashMap> audioClipQueueTimers = new ConcurrentHashMap<String, LinkedHashMap>()
-@Field static Semaphore avtSubscribeMutex = new Semaphore(1)
-@Field static Semaphore zgtSubscribeMutex = new Semaphore(1)
-@Field static Semaphore mrrcSubscribeMutex = new Semaphore(1)
-@Field static Semaphore mrgrcSubscribeMutex = new Semaphore(1)
-@Field static Semaphore unsubscribeMutex = new Semaphore(4)
+// Per-(DNI, sid) subscription mutexes. Previously these were shared static
+// singletons, which caused every driver instance on the hub to serialize
+// through a single permit per sid -- a large contributor to the ZGT retry
+// storm whenever multiple players' 1-hour resub windows aligned.
+@Field static ConcurrentHashMap<String, Semaphore> subscribeMutexes = new ConcurrentHashMap<String, Semaphore>()
+@Field static ConcurrentHashMap<String, Semaphore> unsubscribeMutexes = new ConcurrentHashMap<String, Semaphore>()
 @Field static final Integer SUBSCRIBE_MUTEX_MAX_PERMITS = 1
-@Field static final Integer UNSUBSCRIBE_MUTEX_MAX_PERMITS = 4
+@Field static final Integer UNSUBSCRIBE_MUTEX_MAX_PERMITS = 1
 @Field static final Integer SUBSCRIBE_MUTEX_WAIT_SECONDS = 2
 @Field static final Integer SUBSCRIBE_MUTEX_FALLBACK_RELEASE_SECONDS = 5
+@Field static final Integer SUBSCRIBE_RETRY_MAX_ATTEMPTS = 3
+@Field static ConcurrentHashMap<String, Integer> subscribeRetryAttempts = new ConcurrentHashMap<String, Integer>()
 @Field static ConcurrentHashMap<String, ArrayList<DeviceWrapper>> groupsRegistry = new ConcurrentHashMap<String, ArrayList<DeviceWrapper>>()
 @Field static ConcurrentHashMap<String, LinkedHashMap<String,LinkedHashMap>> statesRegistry = new ConcurrentHashMap<String, LinkedHashMap<String,LinkedHashMap>>()
 @Field static ConcurrentHashMap<String, LinkedHashMap> favoritesMap = new ConcurrentHashMap<String, LinkedHashMap>()
@@ -373,11 +376,7 @@ import java.util.concurrent.TimeUnit
 // =============================================================================
 void initialize() {
   cancelAudioClipWatchdog()
-  normalizeSemaphorePermits(avtSubscribeMutex, SUBSCRIBE_MUTEX_MAX_PERMITS)
-  normalizeSemaphorePermits(zgtSubscribeMutex, SUBSCRIBE_MUTEX_MAX_PERMITS)
-  normalizeSemaphorePermits(mrrcSubscribeMutex, SUBSCRIBE_MUTEX_MAX_PERMITS)
-  normalizeSemaphorePermits(mrgrcSubscribeMutex, SUBSCRIBE_MUTEX_MAX_PERMITS)
-  normalizeSemaphorePermits(unsubscribeMutex, UNSUBSCRIBE_MUTEX_MAX_PERMITS)
+  resetSubscriptionMutexesForDevice()
   maybeCleanupStaticDriverState()
   configure()
   // Stagger resubscriptions across devices to avoid overwhelming the hub on cold boot
@@ -896,12 +895,31 @@ void playText(String text, BigDecimal volume = null) {
   if(getAlwaysUseLoadAudioClip()) { devicePlayText(text, volume) }
   else{ devicePlayTextNoRestore(text, volume) }
 }
+// Public speech entry points. Volume is typed as Object to tolerate callers
+// that pass Integer/Long/String (Rule Machine, webCoRE, user apps). Without
+// this the @CompileStatic signature throws ClassCastException on any caller
+// that doesn't hand us a literal BigDecimal.
+void playTextAndRestore(String text, Object volume = null) { devicePlayText(text, coerceVolume(volume)) }
+void playTextAndResume(String text, Object volume = null) { devicePlayText(text, coerceVolume(volume)) }
+void speak(String text, Object volume = null, String voice = null) { devicePlayText(text, coerceVolume(volume), voice) }
+
 @CompileStatic
-void playTextAndRestore(String text, BigDecimal volume = null) { devicePlayText(text, volume) }
-@CompileStatic
-void playTextAndResume(String text, BigDecimal volume = null) { devicePlayText(text, volume) }
-@CompileStatic
-void speak(String text, BigDecimal volume = null, String voice = null) { devicePlayText(text, volume, voice) }
+BigDecimal coerceVolume(Object volume) {
+  if(volume == null) { return null }
+  if(volume instanceof BigDecimal) { return (BigDecimal) volume }
+  if(volume instanceof Number) { return new BigDecimal(((Number) volume).toString()) }
+  if(volume instanceof CharSequence) {
+    String asString = volume.toString().trim()
+    if(asString == '') { return null }
+    try { return new BigDecimal(asString) }
+    catch(NumberFormatException e) {
+      logWarn("Could not parse volume '${asString}'; ignoring.")
+      return null
+    }
+  }
+  logWarn("Unsupported volume type ${volume.getClass().getName()}; ignoring.")
+  return null
+}
 
 void setTrack(String uri) { componentSetStreamUrlLocal(uri) }
 void playTrack(String uri, BigDecimal volume = null) {
@@ -2688,7 +2706,6 @@ Boolean subValid(String sid) {
 }
 @CompileStatic
 void updateSid(String sid, Map headers) {
-  maybeCleanupStaticDriverState()
   Long expiresEpoch = Instant.now().getEpochSecond() + (2*RESUB_INTERVAL)
   // Store expiry in-memory for subValid() checks
   String expiryKey = "${getDeviceDNI()}-${sid}-expires"
@@ -2701,32 +2718,50 @@ void updateSid(String sid, Map headers) {
 }
 
 void scheduleResubscriptionToEvents(String eventsToResub) {
-  runIn(RESUB_INTERVAL-100, eventsToResub, [overwrite: true])
+  // Stagger the 1-hour resub window deterministically per device so that
+  // multiple players don't all hit the hub at the same second.
+  Integer jitterSeconds = getDeviceResubJitterSeconds()
+  runIn(RESUB_INTERVAL - 100 - jitterSeconds, eventsToResub, [overwrite: true])
+  clearSubscriptionRetryAttempts(eventsToResub)
 }
 
 void retrySubscription(String eventsToRetry, Integer retryTime = 60) {
+  // This is the "real retry" path (used by 412 callback and by the initial
+  // schedule on subscribe-failure), distinct from the mutex-contention
+  // retries gated by scheduleSubscriptionRetry. Reset the mutex-contention
+  // budget so a real server-driven retry doesn't get counted against the
+  // cap.
+  clearSubscriptionRetryAttempts(eventsToRetry)
   runIn(retryTime, eventsToRetry, [overwrite: true])
 }
 
-void removeResub(String resub) { unschedule(resub)}
+// Queue a bounded retry for a subscribe/resubscribe whose mutex attempt
+// failed. Returns true iff a retry was actually scheduled (caller can gate
+// log output on the return value to avoid floods). The retry budget caps the
+// self-rescheduling loop that previously ran indefinitely.
+Boolean scheduleSubscriptionRetry(String eventsToRetry, String clearOnCancel = null) {
+  Integer attempts = incrementSubscriptionRetryAttempts(eventsToRetry)
+  if(attempts > SUBSCRIBE_RETRY_MAX_ATTEMPTS) {
+    logWarn("${eventsToRetry} retry budget exhausted (${attempts - 1} attempts); waiting for next scheduled window.")
+    clearSubscriptionRetryAttempts(eventsToRetry)
+    if(clearOnCancel != null) { clearSubscriptionRetryAttempts(clearOnCancel) }
+    return false
+  }
+  runIn(5, eventsToRetry, [overwrite: true])
+  return true
+}
+
+Integer getDeviceResubJitterSeconds() {
+  String dni = getDNI()
+  if(dni == null || dni == '') { return 0 }
+  return Math.abs(dni.hashCode() % 180)
+}
 
 Integer getRandomLockRetry(Integer low = 8, Integer high = 30) {
-  return Math.abs( rand.nextInt() % (high - low) ) + low
+  return Math.abs(rand.nextInt() % (high - low)) + low
 }
 
-@CompileStatic
-void normalizeSemaphorePermits(Semaphore mutex, Integer permits) {
-  if(mutex == null) { return }
-
-  synchronized(mutex) {
-    Integer availablePermits = mutex.availablePermits()
-    if(availablePermits > permits) {
-      logTrace("Normalizing semaphore permits from ${availablePermits} to ${permits}")
-      mutex.drainPermits()
-      mutex.release(permits)
-    }
-  }
-}
+void removeResub(String resub) { unschedule(resub)}
 
 @CompileStatic
 Boolean tryAcquireMutexWithTimeout(Semaphore mutex, Integer timeoutSeconds, String lockName) {
@@ -2756,14 +2791,49 @@ void releaseMutexIfHeld(Semaphore mutex, Integer maxPermits, String lockName) {
   }
 }
 
-@CompileStatic
 Semaphore getMutexForSid(String sid) {
-  if(sid == 'sid1') {return avtSubscribeMutex}
-  if(sid == 'sid2') {return mrrcSubscribeMutex}
-  if(sid == 'sid3') {return zgtSubscribeMutex}
-  if(sid == 'sid4') {return mrgrcSubscribeMutex}
-  logWarn("Unknown subscription sid '${sid}'")
-  return null
+  if(sid != 'sid1' && sid != 'sid2' && sid != 'sid3' && sid != 'sid4') {
+    logWarn("Unknown subscription sid '${sid}'")
+    return null
+  }
+  String key = "${getDNI()}-${sid}"
+  Semaphore existing = subscribeMutexes.get(key)
+  if(existing != null) { return existing }
+  return subscribeMutexes.computeIfAbsent(key, { k -> new Semaphore(SUBSCRIBE_MUTEX_MAX_PERMITS) })
+}
+
+Semaphore getUnsubscribeMutexForDevice() {
+  String key = getDNI()
+  if(key == null || key == '') { return null }
+  Semaphore existing = unsubscribeMutexes.get(key)
+  if(existing != null) { return existing }
+  return unsubscribeMutexes.computeIfAbsent(key, { k -> new Semaphore(UNSUBSCRIBE_MUTEX_MAX_PERMITS) })
+}
+
+void resetSubscriptionMutexesForDevice() {
+  String dni = getDNI()
+  if(dni == null || dni == '') { return }
+  ['sid1', 'sid2', 'sid3', 'sid4'].each { String sid ->
+    String key = "${dni}-${sid}"
+    subscribeMutexes.put(key, new Semaphore(SUBSCRIBE_MUTEX_MAX_PERMITS))
+  }
+  unsubscribeMutexes.put(dni, new Semaphore(UNSUBSCRIBE_MUTEX_MAX_PERMITS))
+}
+
+String retryAttemptKey(String eventsToRetry) {
+  return "${getDNI()}-${eventsToRetry}"
+}
+
+void clearSubscriptionRetryAttempts(String eventsToRetry) {
+  subscribeRetryAttempts.remove(retryAttemptKey(eventsToRetry))
+}
+
+Integer incrementSubscriptionRetryAttempts(String eventsToRetry) {
+  String key = retryAttemptKey(eventsToRetry)
+  Integer current = subscribeRetryAttempts.get(key) ?: 0
+  Integer next = current + 1
+  subscribeRetryAttempts.put(key, next)
+  return next
 }
 
 void unlockSubscribeMutexAfterTimeout(String sid) {
@@ -2776,15 +2846,19 @@ void unlockSubscribeMutexAfterTimeoutCallback(Map data) {
 }
 
 void unlockUnsubscribeMutexAfterTimeout() {
-  logTrace("Scheduling unlock of unsubscribeMutex in ${SUBSCRIBE_MUTEX_FALLBACK_RELEASE_SECONDS} seconds...")
   runIn(SUBSCRIBE_MUTEX_FALLBACK_RELEASE_SECONDS, 'unlockUnsubscribeMutexAfterTimeoutCallback', [overwrite: true])
 }
 void unlockUnsubscribeMutexAfterTimeoutCallback() {
-  releaseMutexIfHeld(unsubscribeMutex, UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
+  releaseMutexIfHeld(getUnsubscribeMutexForDevice(), UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
 }
 
 @CompileStatic
 void upnpSubscribeGeneric(String sub, String subId, String subPath, String callback, String evtSub) {
+  // Idempotency guard: if we already hold a valid SID for this service, skip
+  // entirely. External callers (e.g. the parent app's 499/GROUP_STATUS_MOVED
+  // handler) can hammer subscribeTo* freely without causing mutex contention
+  // or redundant UPnP SUBSCRIBE traffic.
+  if(subValid(subId)) { return }
   Semaphore mutex = getMutexForSid(subId)
   Boolean acquired = tryAcquireMutexWithTimeout(mutex, SUBSCRIBE_MUTEX_WAIT_SECONDS, "${sub} (${subId})")
   if(acquired == true) {
@@ -2805,13 +2879,12 @@ void upnpSubscribeGeneric(String sub, String subId, String subPath, String callb
       }
     }
   } else {
-    Integer timeout = getRandomLockRetry()
-    logTrace("${sub} attempt in progress...trying again in ${timeout} seconds.")
-    retrySubscription(sub, timeout)
+    if(scheduleSubscriptionRetry(sub)) {
+      logTrace("${sub} attempt in progress, queued retry.")
+    }
   }
 }
 
-@CompileStatic
 void upnpResubscribeGeneric(String resub, String subId, String subPath, String callback, String evtSub) {
   Semaphore mutex = getMutexForSid(subId)
   Boolean acquired = tryAcquireMutexWithTimeout(mutex, SUBSCRIBE_MUTEX_WAIT_SECONDS, "${resub} (${subId})")
@@ -2835,15 +2908,15 @@ void upnpResubscribeGeneric(String resub, String subId, String subPath, String c
       }
     }
   } else {
-    Integer timeout = getRandomLockRetry()
-    logTrace("${resub} attempt in progress...trying again in ${timeout} seconds.")
-    retrySubscription(resub, timeout)
+    if(scheduleSubscriptionRetry(resub)) {
+      logTrace("${resub} attempt in progress, queued retry.")
+    }
   }
 }
 
-@CompileStatic
 void upnpUnsubscribeGeneric(String unsub, String subId, String resub, String evtSub, String callback) {
-  Boolean acquired = tryAcquireMutexWithTimeout(unsubscribeMutex, SUBSCRIBE_MUTEX_WAIT_SECONDS, "${unsub} (${subId})")
+  Semaphore mutex = getUnsubscribeMutexForDevice()
+  Boolean acquired = tryAcquireMutexWithTimeout(mutex, SUBSCRIBE_MUTEX_WAIT_SECONDS, "${unsub} (${subId})")
   if(acquired == true) {
     unlockUnsubscribeMutexAfterTimeout()
     Boolean releaseMutex = true
@@ -2862,8 +2935,6 @@ void upnpUnsubscribeGeneric(String unsub, String subId, String resub, String evt
         removeResub(resub)
         releaseMutex = false
       } else {
-        // Log which values are missing to help with debugging
-        logTrace("${unsub} skipped - missing required data: host=${localUpnpHost != null && localUpnpHost != ''}, sid=${sid != null && sid != ''}, dni=${dni != null && dni != ''}")
         // Clean up anyway since we can't unsubscribe
         if(subId != null) { deleteSid(subId) }
         if(resub != null) { removeResub(resub) }
@@ -2872,13 +2943,13 @@ void upnpUnsubscribeGeneric(String unsub, String subId, String resub, String evt
       logInfo("${unsub} failed due to ${e}")
     } finally {
       if(releaseMutex == true) {
-        releaseMutexIfHeld(unsubscribeMutex, UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
+        releaseMutexIfHeld(mutex, UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
       }
     }
   } else {
-    Integer timeout = getRandomLockRetry()
-    logTrace("${unsub} attempt in progress...trying again in ${timeout} seconds.")
-    retrySubscription(resub, timeout)
+    if(scheduleSubscriptionRetry(unsub, resub)) {
+      logTrace("${unsub} attempt in progress, queued retry.")
+    }
   }
 }
 
@@ -2899,6 +2970,11 @@ void subscribeResubscribeGenericCallback(String sub, String resub, String subId,
     } else if(response?.status == 200) {
       logTrace("Sucessfully subscribed to ${domain}")
       updateSid(subId, response.headers)
+      // Cancel any retries queued by prior "attempt in progress" fallbacks so
+      // they don't keep firing now that we have a valid subscription.
+      unschedule(sub)
+      clearSubscriptionRetryAttempts(sub)
+      clearSubscriptionRetryAttempts(resub)
       scheduleResubscriptionToEvents(resub)
     }
   } finally {
@@ -2906,7 +2982,6 @@ void subscribeResubscribeGenericCallback(String sub, String resub, String subId,
   }
 }
 
-@CompileStatic
 void upnpUnsubscribeCallbackGeneric(String subId, String domain, HubResponse response) {
   try {
     if(response?.status == 412){
@@ -2916,7 +2991,7 @@ void upnpUnsubscribeCallbackGeneric(String subId, String domain, HubResponse res
     }
     deleteSid(subId)
   } finally {
-    releaseMutexIfHeld(unsubscribeMutex, UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
+    releaseMutexIfHeld(getUnsubscribeMutexForDevice(), UNSUBSCRIBE_MUTEX_MAX_PERMITS, 'unsubscribe mutex')
   }
 }
 // /////////////////////////////////////////////////////////////////////////////
@@ -3027,6 +3102,16 @@ void subscribeToZgtEvents() {
   String evtSub = ZGT_EVENTS
   String callback = ZGT_EVENTS_CALLBACK
   upnpSubscribeGeneric(sub, subId, subPath, callback, evtSub)
+}
+
+// Entry point used by the parent app when a GROUP_STATUS_MOVED 499 arrives.
+// Skips the subscribe entirely when the ZGT subscription is still valid --
+// GROUP_STATUS_MOVED does not invalidate the UPnP SID, it only means the
+// coordinator changed. Otherwise we batch burst-y callers into a single 2s
+// delayed subscribe so storms of 499s coalesce into one network request.
+void requestZgtResub() {
+  if(subValid('sid3')) { return }
+  runIn(2, 'subscribeToZgtEvents', [overwrite: true])
 }
 
 @CompileStatic


### PR DESCRIPTION
## Summary
This PR addresses critical performance issues in the Sonos driver caused by shared subscription mutexes and unbounded retry loops. The changes implement per-device subscription locking, bounded retry budgets, and debouncing for GROUP_STATUS_MOVED events to prevent hub overload during multi-player scenarios.

## Key Changes

### Subscription Mutex Refactoring
- **Replaced global mutexes with per-device mutexes**: Changed from 5 shared static `Semaphore` instances (`avtSubscribeMutex`, `zgtSubscribeMutex`, etc.) to `ConcurrentHashMap`-based per-(DNI, sid) mutexes. This eliminates the bottleneck where every driver instance on the hub serialized through a single permit per subscription type.
- **Per-device unsubscribe mutex**: Unsubscribe operations now use a per-device mutex instead of a shared global one, reducing contention during bulk unsubscribe operations.
- **Reduced unsubscribe permits**: Changed `UNSUBSCRIBE_MUTEX_MAX_PERMITS` from 4 to 1 to prevent concurrent unsubscribe attempts on the same device.

### Subscription Retry Budget
- **Added bounded retry mechanism**: Introduced `SUBSCRIBE_RETRY_MAX_ATTEMPTS` (3) and `subscribeRetryAttempts` tracking to cap self-rescheduling loops that previously ran indefinitely. The new `scheduleSubscriptionRetry()` method returns a boolean indicating whether a retry was actually scheduled.
- **Replaced random backoff with deterministic jitter**: Subscription resubscription windows now use `getDeviceResubJitterSeconds()` to stagger the 1-hour resub window per device based on DNI hash, preventing synchronized resub storms across multiple players.
- **Idempotency guard**: Added `subValid()` check in `upnpSubscribeGeneric()` to skip redundant subscribe attempts when a valid SID already exists.

### ZGT Resub Storm Prevention
- **Added `requestZgtResub()` entry point**: New method in the driver that checks subscription validity before attempting resubscribe, allowing the parent app to safely call it without causing mutex contention.
- **Parent app debouncing**: Implemented `shouldRequestZgtResub()` in the parent app with a 60-second minimum interval per device to coalesce burst 499 (GROUP_STATUS_MOVED) responses into a single network request.
- **Removed debug logging**: Eliminated verbose trace logs from unsubscribe path to reduce log spam.

### Volume Parameter Coercion
- **Added `coerceVolume()` helper**: Public speech entry points (`playTextAndRestore`, `playTextAndResume`, `speak`) now accept `Object` volume parameter and coerce it to `BigDecimal`. This prevents `ClassCastException` when callers (Rule Machine, webCoRE, user apps) pass Integer, Long, or String values instead of literal BigDecimal.
- **Removed @CompileStatic from speech methods**: Allows dynamic type handling for volume parameter flexibility.

### Code Cleanup
- **Removed `normalizeSemaphorePermits()` method**: No longer needed with per-device mutex initialization via `resetSubscriptionMutexesForDevice()`.
- **Simplified mutex acquisition logic**: Removed random retry delays in favor of bounded retry budget; replaced with deterministic 5-second retry intervals.
- **Removed redundant cleanup call**: Eliminated `maybeCleanupStaticDriverState()` from `updateSid()` to reduce unnecessary processing.

## Notable Implementation Details
- Mutex keys use format `"${DNI}-${sid}"` for subscriptions and `"${DNI}"` for unsubscribes to ensure proper per-device isolation.
- Retry attempt tracking uses the same key format to maintain per-device retry budgets.
- The `computeIfAbsent()` pattern ensures thread-safe lazy initialization of mutexes on first access.
- Successful subscriptions now explicitly cancel queued retries via `removeResub()` and `clearSubscriptionRetryAttempts()` to prevent stale retry callbacks.

https://claude.ai/code/session_018i4z2dimv4cDGNRptA66yV