### PR TITLE
Fix TTS duration type coercion in audio clip handling

### DIFF
--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -962,7 +962,8 @@ void playTrackAndResume(String uri, BigDecimal volume = null) { playerLoadAudioC
 void devicePlayText(String text, BigDecimal volume = null, String voice = null) {
   LinkedHashMap tts = textToSpeech(text, voice)
   if(hasAudioClipCapability() == true) {
-    playerLoadAudioClip(tts.uri, volume, tts.duration)
+    Integer ttsDuration = coerceClipDuration(tts?.duration) ?: 0
+    playerLoadAudioClip(tts.uri as String, volume, ttsDuration)
   } else {
     if(volume) { volume += getTTSBoostAmount() }
     else { volume = getPlayerVolume() + getTTSBoostAmount() }
@@ -5993,8 +5994,19 @@ void cancelAudioClipWatchdog() {
   atomicState.audioClipPlaying = false
 }
 
+// textToSpeech() returns duration as a String on some TTS providers, so a raw
+// `duration > 0` on the Map value invokes String.compareTo(Integer) and throws
+// "Integer cannot be cast to String". Always coerce via toIntegerOrNull first.
+private Integer coerceClipDuration(Object raw) {
+  if(raw == null) { return null }
+  if(raw instanceof Number) { return ((Number) raw).intValue() }
+  try { return new BigDecimal(raw.toString().trim()).intValue() }
+  catch(Exception ignored) { return null }
+}
+
 void startAudioClipWatchdog(Map clipMessage) {
-  Integer clipDuration = (clipMessage?.duration != null && clipMessage.duration > 0) ? clipMessage.duration as Integer : AUDIO_CLIP_DEFAULT_WATCHDOG_SECONDS
+  Integer parsed = coerceClipDuration(clipMessage?.duration)
+  Integer clipDuration = (parsed != null && parsed > 0) ? parsed : AUDIO_CLIP_DEFAULT_WATCHDOG_SECONDS
   Integer totalDuration = clipDuration * AUDIO_CLIP_WATCHDOG_MULTIPLIER
   atomicState.audioClipQueueStartTime = now()
   atomicState.audioClipQueueTotalDuration = totalDuration
@@ -6003,7 +6015,8 @@ void startAudioClipWatchdog(Map clipMessage) {
 }
 
 void extendAudioClipWatchdog(Map clipMessage) {
-  Integer clipDuration = (clipMessage?.duration != null && clipMessage.duration > 0) ? clipMessage.duration as Integer : AUDIO_CLIP_DEFAULT_WATCHDOG_SECONDS
+  Integer parsed = coerceClipDuration(clipMessage?.duration)
+  Integer clipDuration = (parsed != null && parsed > 0) ? parsed : AUDIO_CLIP_DEFAULT_WATCHDOG_SECONDS
   Integer totalDuration = (atomicState.audioClipQueueTotalDuration ?: 0) as Integer
   totalDuration += clipDuration * AUDIO_CLIP_WATCHDOG_MULTIPLIER
   atomicState.audioClipQueueTotalDuration = totalDuration

--- a/Drivers/Component/SonosAdvPlayer.groovy
+++ b/Drivers/Component/SonosAdvPlayer.groovy
@@ -5996,12 +5996,13 @@ void cancelAudioClipWatchdog() {
 
 // textToSpeech() returns duration as a String on some TTS providers, so a raw
 // `duration > 0` on the Map value invokes String.compareTo(Integer) and throws
-// "Integer cannot be cast to String". Always coerce via toIntegerOrNull first.
+// "Integer cannot be cast to String". Always coerce via coerceClipDuration() first.
 private Integer coerceClipDuration(Object raw) {
   if(raw == null) { return null }
   if(raw instanceof Number) { return ((Number) raw).intValue() }
   try { return new BigDecimal(raw.toString().trim()).intValue() }
-  catch(Exception ignored) { return null }
+  catch(NumberFormatException ignored) { return null }
+  catch(ArithmeticException ignored) { return null }
 }
 
 void startAudioClipWatchdog(Map clipMessage) {


### PR DESCRIPTION
## Summary
Fixed type coercion issues when handling text-to-speech (TTS) duration values that may be returned as strings by some TTS providers, preventing ClassCastException errors during audio clip playback.

## Key Changes
- Added `coerceClipDuration()` helper method to safely convert duration values from various types (String, Number, null) to Integer
  - Handles null values gracefully
  - Converts Number types directly via `intValue()`
  - Parses String representations via BigDecimal for precision before converting to int
  - Returns null for unparseable values
- Updated `devicePlayText()` to use the new coercion method and explicitly cast URI to String
- Updated `startAudioClipWatchdog()` to use `coerceClipDuration()` instead of unsafe direct casting
- Updated `extendAudioClipWatchdog()` to use `coerceClipDuration()` instead of unsafe direct casting

## Implementation Details
The root cause was that some TTS providers return duration as a String rather than a Number. The original code attempted direct comparison (`clipMessage.duration > 0`) which invokes `String.compareTo(Integer)` and throws a ClassCastException. The new `coerceClipDuration()` method ensures consistent Integer handling across all TTS provider implementations while maintaining backward compatibility with numeric duration values.

https://claude.ai/code/session_01QzUDNn4D35xcTgUfwRAiz7