### PR TITLE
CI: add Claude PR review and auto-fix-on-failure workflows

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,150 @@
+---
+description: Multi-agent code review for Hubitat Groovy apps, drivers, and libraries. Dispatches specialized subagents in parallel and posts inline + summary comments on the PR.
+allowed-tools: Bash(gh *), Bash(git *), Read, Grep, Glob, Agent
+---
+
+# /review — Hubitat-Public PR review
+
+You are reviewing a pull request against the `Hubitat-Public` repository. This codebase is a collection of Groovy apps, drivers, and libraries deployed directly to a Hubitat Elevation home automation hub. **There is no compile or test step** — code correctness is verified by deployment to actual hardware. Your review must therefore be a careful static analysis that catches the failure modes Hubitat Groovy is prone to.
+
+## Read this first (project context)
+
+Before doing anything else, read these files to load the conventions you'll be enforcing:
+
+1. `CLAUDE.md` — code style rules, what-to-preserve list, async HTTP retry pattern
+2. `.github/copilot-instructions.md` — additional convention notes
+3. `Libraries/UtilitiesAndLoggingLibrary.groovy` — the logging methods, `tryCreateAccessToken()`, retry helpers that drivers/apps depend on
+
+If a file in the diff `#include`s a library, also read that library so you understand what symbols (especially imports) the library was providing.
+
+## Workflow
+
+1. **Gather context.** Run `gh pr view --json number,title,body,baseRefName,headRefName,files`. Read the PR description carefully — it often explains why a change that looks suspicious is actually intentional.
+2. **Get the diff.** Run `git diff "$PR_BASE_REF"...HEAD` (or `gh pr diff`) to see the full set of changes. Note added, deleted, and modified files separately.
+3. **Decide if review is even needed.** If the diff only touches `Bundles/` (auto-generated), `PackageManifests/*/packageManifest.json` (release metadata), `Resources/`, `Readme/`, or `repository.json` version bumps — post a one-line summary noting the change is mechanical/release-only and exit without dispatching subagents.
+4. **Dispatch the three review agents in parallel** (single message, multiple Agent tool calls). See "Agent rubrics" below.
+5. **Filter findings.** Drop anything below 80% confidence. The goal is high signal; do not surface speculative concerns.
+6. **Post results.** Inline `file:line` comments for each surviving finding via `gh pr review --comment` or `gh api`. Then post one summary comment grouping findings by severity. If zero findings clear the bar, post `"No blocking issues found."` so the user knows the review actually ran.
+
+## Agent rubrics
+
+Dispatch all three agents with the **full diff** plus the **base-branch versions** of any modified files (so they can see deletions and renames in context). Each agent returns findings in the format below.
+
+### Agent 1 — Hubitat-correctness
+
+**Focus:** platform-specific gotchas that pass static checks but break the running hub.
+
+Block-level severity (always block-tag):
+
+- **Removed `#include` without restoring imports.** When `#include dwinks.UtilitiesAndLoggingLibrary` (or any other library include) is removed, the file MUST add back any types the library was providing transitively. Check for these in particular and verify each is now imported explicitly if used:
+  - `import groovy.transform.Field` — required for `@Field static final` declarations. **Most common breakage.**
+  - `import groovy.json.JsonOutput` — required for `JsonOutput.toJson()` / `JsonOutput.prettyPrint()`
+  - `import groovy.transform.CompileStatic` — required for `@CompileStatic` annotation
+  - `import com.hubitat.app.ChildDeviceWrapper` — required when used as a declared type
+  - `import com.hubitat.app.DeviceWrapper` — required when used as a method-param type
+  - `import hubitat.scheduling.AsyncResponse` — required when used in async callback signatures
+  Any missing import causes an "unparseable" error on the hub. Hubitat does NOT auto-import these.
+
+- **`pauseExecution(...)` introduced.** This is a blocking call that halts the entire thread. Use `runIn(seconds, 'methodName')` for delays. The only exception is when the explicit intent is to block the thread (and the PR description says so).
+
+- **Attribute or state value set to `null`.** `sendEvent(value: null)` and `state.x = null` do not persist properly on the hub. Reset patterns must use valid non-null values:
+  - Strings → `''`
+  - JSON strings → `'{}'`
+  - Numbers → `0`
+  - String-typed numbers → `'0'`
+  - Enums → a valid enum value like `'off'`
+
+- **Webhook path changed in `mappings { path("/...") }`.** External systems hold these URLs. Renaming silently breaks integrations. Adding new paths is fine; modifying or deleting existing ones is block-level.
+
+- **Existing `state.*` keys removed or renamed.** Corrupts running installations on user hubs. New keys are fine; modifying existing ones is block-level.
+
+- **Existing `settings.*` keys removed or renamed (or types changed).** Loses user configuration on existing installations.
+
+- **Lifecycle hooks deleted or renamed.** `installed()`, `updated()`, `uninstalled()`, `initialize()` are called by the platform. Do not touch.
+
+- **`dwinks` namespace changed** in `definition()`, `metadata { definition() }`, or `library()` blocks.
+
+- **Hand-edits to files under `Bundles/`.** These are auto-generated by GitHub Actions (`SonosAdvancedBundles.yml`, `ThirdRealityBundles.yml`, `UtilitiesAndLoggingLibrary.yml`). Hand-edits will be overwritten on the next workflow run. The fix is to edit source files in `Apps/`, `Drivers/`, or `Libraries/` instead.
+
+- **New file under `Apps/` or `Drivers/` introducing a new top-level package without a corresponding `PackageManifests/<name>/packageManifest.json` and an entry in root `repository.json`.** Adding files to existing packages is fine; introducing new packages requires manifest and registry updates.
+
+### Agent 2 — Code quality
+
+**Focus:** style, types, and convention compliance from `CLAUDE.md`.
+
+High-severity:
+
+- Raw `log.debug` / `log.info` / `log.warn` / `log.error` / `log.trace` calls instead of the wrapped `logDebug` / `logInfo` / `logWarn` / `logError` / `logTrace` from `UtilitiesAndLoggingLibrary`. **Exception:** the library itself, and the BidirectionalSync app/child app (which are explicitly standalone — see `MEMORY.md` note).
+- `def` used as a type where a concrete type is known and clear (`String`, `Integer`, `Long`, `Boolean`, `Map`, `List`, `BigDecimal`).
+- Method calls without parentheses (e.g. `logInfo "x"` instead of `logInfo("x")`). CLAUDE.md mandates parens.
+- Control structures without braces (e.g. `if (x) doThing()` instead of `if (x) { doThing() }`). CLAUDE.md mandates braces.
+- Constants declared without `@Field static final`.
+- New Groovy source file missing the MIT license header.
+- Async HTTP callback that doesn't follow the retry pattern from `UtilitiesAndLoggingLibrary`:
+  ```groovy
+  void callbackMethod(AsyncResponse response, Map data) {
+    if (isHttpResponseFailure(response)) {
+      handleAsyncHttpFailureWithRetry(response, 'retryMethod')
+      return
+    }
+    // process success
+  }
+  ```
+  Missing the failure check or the retry helper means transient HTTP errors silently swallow data.
+
+Medium-severity:
+
+- Missing `@CompileStatic` on a file that has no dynamic-only Groovy idioms in scope (closures with implicit delegate access, builders, etc.). `@CompileStatic` catches type errors at compile time.
+- `descriptionTextEnable` toggle missing on user-visible info logs in drivers.
+- New OAuth endpoint not using `tryCreateAccessToken()`.
+
+### Agent 3 — Security & secrets
+
+**Focus:** anything that leaks credentials or makes outbound calls without justification.
+
+Block-level:
+
+- API keys, OAuth tokens, passwords, or other secrets hardcoded into source. Must come from `settings` (user input via preferences UI) or be passed in at runtime. Never `static final String API_KEY = "..."`.
+- New external network calls (asynchttpGet/Post to a domain not already used in the codebase) without justification in the PR description. Hubitat is a local-first platform; new outbound calls are a meaningful change.
+- Logging that could leak access tokens, session cookies, full HTTP response bodies, or PII. Tokens in particular: `logDebug("response: ${response.data}")` is suspect if `response` may contain auth headers.
+- OAuth handler not using `tryCreateAccessToken()`.
+
+## Output format
+
+Each finding from each agent must use this exact format:
+
+```
+[severity] [category] (confidence: NN)
+file/path.groovy:LINE
+<one-line description of the issue>
+<optional: 1-3 lines of rationale or fix suggestion>
+```
+
+- `severity` ∈ `block`, `high`, `medium`
+- `category` ∈ `hubitat-correctness`, `code-quality`, `security`
+- `confidence` is an integer 0-100. Drop everything below 80.
+
+After collecting and filtering all findings, post:
+
+1. **Inline review comments** for each finding using `gh api repos/$REPO/pulls/$PR_NUMBER/comments` or `gh pr review --comment --body "..." -F -`. Anchor each comment to the specific `file:line` from the finding.
+2. **A summary PR comment** using `gh pr comment $PR_NUMBER --body "..."` with this structure:
+   ```
+   ## Claude review summary
+
+   **Block (N):** brief list
+   **High (N):** brief list
+   **Medium (N):** brief list
+
+   See inline comments for details.
+   ```
+
+If zero findings survived filtering, post a single summary comment: `"No blocking issues found."` — this confirms the review actually ran.
+
+## Constraints — what NOT to do
+
+- **Do not** run `npm test`, `pytest`, `gradle`, or any test/build command. There is no build for this codebase.
+- **Do not** edit code in the PR. This is a review, not a fix.
+- **Do not** flag stylistic preferences not codified in `CLAUDE.md` (tabs vs spaces, line length, etc.).
+- **Do not** fabricate findings to justify the review running. If the diff is clean, say so.
+- **Do not** comment on `Bundles/` content — auto-generated.
+- **Do not** comment on `PackageManifests/*/packageManifest.json` version bumps — release metadata.

--- a/.github/workflows/claude-fix-on-failure.yml
+++ b/.github/workflows/claude-fix-on-failure.yml
@@ -1,0 +1,131 @@
+name: Auto-issue on CI failure
+
+# When any of the listed workflows finish with a failure, open (or update)
+# a GitHub issue mentioning @claude. The existing claude.yml workflow
+# listens for @claude in issue bodies/titles and will pick this up
+# automatically, attempting a fix.
+#
+# Workflows excluded from this trigger -- creating an issue when one of these
+# fails would risk a feedback loop:
+#   - "Claude PR Review"            (Claude reviewing Claude reviewing Claude...)
+#   - "Claude Code"                 (Claude's own runs)
+#   - "Auto-issue on CI failure"    (would self-trigger on its own failures)
+on:
+  workflow_run:
+    workflows:
+      - "Create ThirdReality Bundle"
+      - "Create Sonos Advanced Controller Bundle"
+      - "Create UtilitiesAndLoggingLibrary Bundle"
+      - "Release Sonos Advanced Controller"
+      - "Release Gemini Text Rewriter"
+    types: [completed]
+
+# Static group serializes all auto-issue jobs across the repo. Since each
+# job runs in seconds and CI failures are rare, this is cheap insurance
+# against double-fire races. The script-level dedup (search-then-comment)
+# is the primary safeguard against duplicate issues.
+concurrency:
+  group: ci-failure-issue
+  cancel-in-progress: false
+
+jobs:
+  open_fix_issue:
+    name: Open @claude fix issue
+    # Hoist all workflow_run metadata into env so the if: condition and
+    # the shell body both reference values via env.X / "$X" rather than
+    # mixing ${{ github.event.* }} substitutions through the file. None of
+    # these values are user-controlled (workflow_run trigger metadata is
+    # GitHub-managed) but the env-only convention keeps the file
+    # audit-friendly.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO_FULL_NAME: ${{ github.repository }}
+      WF_NAME: ${{ github.event.workflow_run.name }}
+      WF_HTML_URL: ${{ github.event.workflow_run.html_url }}
+      WF_RUN_ID: ${{ github.event.workflow_run.id }}
+      WF_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      WF_EVENT: ${{ github.event.workflow_run.event }}
+      WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      WF_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+    # workflow_run fires for every completion (success, failure, cancelled);
+    # only act on actual failures.
+    if: env.WF_CONCLUSION == 'failure'
+    runs-on: self-hosted
+    permissions:
+      issues: write
+      actions: read
+      contents: read
+    steps:
+      - name: Open or comment on @claude fix issue
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Stable title -- used for de-duplication. If an open issue with
+          # this exact title already exists, we comment on it instead of
+          # opening a new one. Prevents fix-loop spam if Claude's fix
+          # introduces another failure of the same workflow on the same branch.
+          TITLE="[CI failure] $WF_NAME on $WF_HEAD_BRANCH"
+
+          # Search open issues with the exact title. The --search filter is
+          # fuzzy, so we narrow with a strict equality check via a separate
+          # jq invocation -- gh's --jq does not pass --arg through to jq, so
+          # we pipe the JSON out and run jq ourselves.
+          existing=$(gh issue list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --search "$TITLE in:title" \
+            --json number,title \
+            | jq -r --arg t "$TITLE" '[.[] | select(.title == $t)] | first | .number // empty')
+
+          # Body is shared between the create and comment paths. The @claude
+          # mention at the top is what triggers .github/workflows/claude.yml.
+          # Backticks are escaped (\`) since the heredoc tag is unquoted, so
+          # bare backticks would otherwise trigger command substitution.
+          BODY=$(cat <<EOF
+          @claude please investigate and fix this CI failure.
+
+          - **Workflow:** \`$WF_NAME\`
+          - **Branch:** \`$WF_HEAD_BRANCH\`
+          - **Commit:** \`$WF_HEAD_SHA\`
+          - **Triggering event:** \`$WF_EVENT\`
+          - **Conclusion:** \`$WF_CONCLUSION\`
+          - **Run:** $WF_HTML_URL
+          - **Subject:** $WF_DISPLAY_TITLE
+
+          ## Suggested approach
+
+          1. Read the failed step output:
+             \`gh run view $WF_RUN_ID --log-failed --repo $REPO_FULL_NAME\`
+          2. Identify the root cause. The bundle workflows zip Groovy source
+             files under \`Apps/\`, \`Drivers/\`, and \`Libraries/\` -- failures
+             here are usually syntax errors or missing files in the source tree.
+             The release workflows update versions and tag releases -- failures
+             are usually metadata or git-push errors.
+          3. Open a PR targeting \`$WF_HEAD_BRANCH\` with the fix.
+          4. Once the fix lands and CI is green, close this issue.
+
+          ## Skip and stop if
+
+          - The failure looks transient (runner timeout, GitHub outage,
+            secret expiration).
+          - The failure is in auto-generated content under \`Bundles/\`
+            (re-run the workflow rather than editing).
+          - You can't reach a high-confidence root cause from the logs alone.
+            Comment back with what you found and stop -- do not guess at a fix.
+          EOF
+          )
+
+          if [ -n "$existing" ]; then
+            echo "Existing open issue #$existing matches; appending comment instead of creating duplicate."
+            gh issue comment "$existing" \
+              --repo "$REPO_FULL_NAME" \
+              --body "$BODY"
+          else
+            echo "No matching open issue; creating a new one."
+            gh issue create \
+              --repo "$REPO_FULL_NAME" \
+              --title "$TITLE" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/claude-fix-on-failure.yml
+++ b/.github/workflows/claude-fix-on-failure.yml
@@ -31,32 +31,12 @@ concurrency:
 jobs:
   open_fix_issue:
     name: Open @claude fix issue
-    # Hoist workflow_run metadata into env so the shell body reads them as
-    # $X variables rather than splicing ${{ github.event.* }} into run:
-    # blocks. None of these are user-controlled (workflow_run metadata is
-    # GitHub-managed) but the env: pattern is the safe-by-default GitHub
-    # Actions convention for shell access. NOTE: the job-level if: cannot
-    # use env (GitHub does not expose env context to job if:), so the
-    # failure-only gate below references github.event.* directly.
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO_FULL_NAME: ${{ github.repository }}
-      WF_NAME: ${{ github.event.workflow_run.name }}
-      WF_HTML_URL: ${{ github.event.workflow_run.html_url }}
-      WF_RUN_ID: ${{ github.event.workflow_run.id }}
-      WF_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-      WF_EVENT: ${{ github.event.workflow_run.event }}
-      WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-      WF_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
     # workflow_run fires for every completion (success, failure, cancelled);
-    # only act on actual failures. NOTE: the env context is NOT available in
-    # job-level if: per GitHub Actions context-availability rules, so we
+    # only act on actual failures. The env context is NOT available in
+    # job-level if: (per GitHub Actions context-availability rules), so we
     # reference github.event.workflow_run.conclusion directly. The conclusion
-    # value is a GitHub-controlled enum ("success" | "failure" | "cancelled" |
-    # "skipped" | "neutral" | "timed_out" | ...), not user input, so there's
-    # no injection surface here even though the env: pattern would normally
-    # be safer.
+    # is a GitHub-controlled enum ("success" | "failure" | "cancelled" |
+    # "skipped" | "neutral" | "timed_out" | ...), not user input.
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: self-hosted
     permissions:
@@ -65,74 +45,81 @@ jobs:
       contents: read
     steps:
       - name: Open or comment on @claude fix issue
-        shell: bash
-        run: |
-          set -euo pipefail
+        # Uses actions/github-script (the established pattern in this repo --
+        # see release-sonos-advanced.yml) instead of the gh CLI, which is not
+        # installed on the self-hosted runner. github-script bundles its own
+        # Node runtime + Octokit, so it has no runner-side dependencies.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
 
-          # Stable title -- used for de-duplication. If an open issue with
-          # this exact title already exists, we comment on it instead of
-          # opening a new one. Prevents fix-loop spam if Claude's fix
-          # introduces another failure of the same workflow on the same branch.
-          TITLE="[CI failure] $WF_NAME on $WF_HEAD_BRANCH"
+            // Stable title -- used for de-duplication. If an open issue with
+            // this exact title already exists, comment on it instead of
+            // creating a new one. Prevents fix-loop spam if Claude's fix
+            // introduces another failure of the same workflow on the same
+            // branch.
+            const title = `[CI failure] ${wf.name} on ${wf.head_branch}`;
 
-          # Search open issues with the exact title. The --search filter is
-          # fuzzy, so we narrow with a strict equality check via a separate
-          # jq invocation -- gh's --jq does not pass --arg through to jq, so
-          # we pipe the JSON out and run jq ourselves.
-          existing=$(gh issue list \
-            --repo "$REPO_FULL_NAME" \
-            --state open \
-            --search "$TITLE in:title" \
-            --json number,title \
-            | jq -r --arg t "$TITLE" '[.[] | select(.title == $t)] | first | .number // empty')
+            // Body shared between the create and comment paths. The @claude
+            // mention at the top is what triggers .github/workflows/claude.yml.
+            const body = [
+              `@claude please investigate and fix this CI failure.`,
+              ``,
+              `- **Workflow:** \`${wf.name}\``,
+              `- **Branch:** \`${wf.head_branch}\``,
+              `- **Commit:** \`${wf.head_sha}\``,
+              `- **Triggering event:** \`${wf.event}\``,
+              `- **Conclusion:** \`${wf.conclusion}\``,
+              `- **Run:** ${wf.html_url}`,
+              `- **Subject:** ${wf.display_title}`,
+              ``,
+              `## Suggested approach`,
+              ``,
+              `1. Investigate the failed run via the URL above. The failed step`,
+              `   logs can be fetched from the GitHub API at`,
+              `   \`/repos/${owner}/${repo}/actions/runs/${wf.id}/logs\` (returns a`,
+              `   redirect to a zip of all logs), or you can read the run page`,
+              `   directly. The "actions: read" permission has already been granted.`,
+              `2. Identify the root cause. The bundle workflows zip Groovy source`,
+              `   files under \`Apps/\`, \`Drivers/\`, and \`Libraries/\` -- failures`,
+              `   here are usually syntax errors or missing files in the source tree.`,
+              `   The release workflows update versions and tag releases -- failures`,
+              `   are usually metadata or git-push errors.`,
+              `3. Open a PR targeting \`${wf.head_branch}\` with the fix.`,
+              `4. Once the fix lands and CI is green, close this issue.`,
+              ``,
+              `## Skip and stop if`,
+              ``,
+              `- The failure looks transient (runner timeout, GitHub outage,`,
+              `  secret expiration).`,
+              `- The failure is in auto-generated content under \`Bundles/\``,
+              `  (re-run the workflow rather than editing).`,
+              `- You can't reach a high-confidence root cause from the logs alone.`,
+              `  Comment back with what you found and stop -- do not guess at a fix.`,
+            ].join('\n');
 
-          # Body is shared between the create and comment paths. The @claude
-          # mention at the top is what triggers .github/workflows/claude.yml.
-          # Backticks are escaped (\`) since the heredoc tag is unquoted, so
-          # bare backticks would otherwise trigger command substitution.
-          BODY=$(cat <<EOF
-          @claude please investigate and fix this CI failure.
+            // Search for an existing open issue with the exact title. We list
+            // open issues directly (rather than via the search API) to avoid
+            // search-indexing lag, which would otherwise let a fast-firing
+            // second failure create a duplicate before the first issue is
+            // indexed. listForRepo returns BOTH issues and PRs; filter PRs out
+            // via the .pull_request property which is absent on real issues.
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const existing = open.find(i => !i.pull_request && i.title === title);
 
-          - **Workflow:** \`$WF_NAME\`
-          - **Branch:** \`$WF_HEAD_BRANCH\`
-          - **Commit:** \`$WF_HEAD_SHA\`
-          - **Triggering event:** \`$WF_EVENT\`
-          - **Conclusion:** \`$WF_CONCLUSION\`
-          - **Run:** $WF_HTML_URL
-          - **Subject:** $WF_DISPLAY_TITLE
-
-          ## Suggested approach
-
-          1. Read the failed step output:
-             \`gh run view $WF_RUN_ID --log-failed --repo $REPO_FULL_NAME\`
-          2. Identify the root cause. The bundle workflows zip Groovy source
-             files under \`Apps/\`, \`Drivers/\`, and \`Libraries/\` -- failures
-             here are usually syntax errors or missing files in the source tree.
-             The release workflows update versions and tag releases -- failures
-             are usually metadata or git-push errors.
-          3. Open a PR targeting \`$WF_HEAD_BRANCH\` with the fix.
-          4. Once the fix lands and CI is green, close this issue.
-
-          ## Skip and stop if
-
-          - The failure looks transient (runner timeout, GitHub outage,
-            secret expiration).
-          - The failure is in auto-generated content under \`Bundles/\`
-            (re-run the workflow rather than editing).
-          - You can't reach a high-confidence root cause from the logs alone.
-            Comment back with what you found and stop -- do not guess at a fix.
-          EOF
-          )
-
-          if [ -n "$existing" ]; then
-            echo "Existing open issue #$existing matches; appending comment instead of creating duplicate."
-            gh issue comment "$existing" \
-              --repo "$REPO_FULL_NAME" \
-              --body "$BODY"
-          else
-            echo "No matching open issue; creating a new one."
-            gh issue create \
-              --repo "$REPO_FULL_NAME" \
-              --title "$TITLE" \
-              --body "$BODY"
-          fi
+            if (existing) {
+              core.info(`Existing open issue #${existing.number} matches; commenting instead of creating duplicate.`);
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number, body,
+              });
+            } else {
+              core.info('No matching open issue; creating a new one.');
+              const created = await github.rest.issues.create({
+                owner, repo, title, body,
+              });
+              core.info(`Created issue #${created.data.number}.`);
+            }

--- a/.github/workflows/claude-fix-on-failure.yml
+++ b/.github/workflows/claude-fix-on-failure.yml
@@ -31,12 +31,13 @@ concurrency:
 jobs:
   open_fix_issue:
     name: Open @claude fix issue
-    # Hoist all workflow_run metadata into env so the if: condition and
-    # the shell body both reference values via env.X / "$X" rather than
-    # mixing ${{ github.event.* }} substitutions through the file. None of
-    # these values are user-controlled (workflow_run trigger metadata is
-    # GitHub-managed) but the env-only convention keeps the file
-    # audit-friendly.
+    # Hoist workflow_run metadata into env so the shell body reads them as
+    # $X variables rather than splicing ${{ github.event.* }} into run:
+    # blocks. None of these are user-controlled (workflow_run metadata is
+    # GitHub-managed) but the env: pattern is the safe-by-default GitHub
+    # Actions convention for shell access. NOTE: the job-level if: cannot
+    # use env (GitHub does not expose env context to job if:), so the
+    # failure-only gate below references github.event.* directly.
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_FULL_NAME: ${{ github.repository }}
@@ -49,8 +50,14 @@ jobs:
       WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
       WF_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
     # workflow_run fires for every completion (success, failure, cancelled);
-    # only act on actual failures.
-    if: env.WF_CONCLUSION == 'failure'
+    # only act on actual failures. NOTE: the env context is NOT available in
+    # job-level if: per GitHub Actions context-availability rules, so we
+    # reference github.event.workflow_run.conclusion directly. The conclusion
+    # value is a GitHub-controlled enum ("success" | "failure" | "cancelled" |
+    # "skipped" | "neutral" | "timed_out" | ...), not user input, so there's
+    # no injection surface here even though the env: pattern would normally
+    # be safer.
+    if: github.event.workflow_run.conclusion == 'failure'
     runs-on: self-hosted
     permissions:
       issues: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,102 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel a stale review when new commits land on the same PR.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude code review
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    timeout-minutes: 25
+    steps:
+      - name: Checkout PR head with full history
+        uses: actions/checkout@v6
+        with:
+          # Need history to diff against the base branch.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Wait for other PR checks to complete
+        id: wait_for_ci
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Excluded from the wait-and-pass check (this job's own check name).
+          SELF_CHECK_NAME: 'Claude code review'
+        run: |
+          set -euo pipefail
+
+          # Let GitHub queue any other PR-triggered workflows before polling.
+          # When a PR is opened, multiple workflows schedule in parallel; if we
+          # poll immediately we can race past checks that haven't registered yet.
+          echo "Waiting 60s for other workflows to register..."
+          sleep 60
+
+          api_url="repos/$REPO_FULL_NAME/commits/$PR_HEAD_SHA/check-runs?per_page=100"
+
+          # Poll until every non-self check reaches a terminal state. The
+          # job-level timeout-minutes (25) bounds the total wait.
+          while :; do
+            data=$(gh api "$api_url")
+            in_flight=$(echo "$data" | jq --arg self "$SELF_CHECK_NAME" \
+              '[.check_runs[] | select(.name != $self and (.status == "queued" or .status == "in_progress"))] | length')
+            [ "$in_flight" = "0" ] && break
+            echo "Waiting on $in_flight other check(s)..."
+            sleep 30
+          done
+
+          # All other checks are done -- did any not pass? Treat success,
+          # skipped, and neutral as passing; everything else (failure, cancelled,
+          # timed_out, action_required, stale) blocks the review.
+          failed=$(echo "$data" | jq --arg self "$SELF_CHECK_NAME" \
+            '[.check_runs[] | select(.name != $self and .conclusion != null and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
+
+          if [ "$failed" != "0" ]; then
+            echo "::warning::$failed other check(s) did not pass; skipping Claude review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "All other checks passed; proceeding with Claude review."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude review
+        if: steps.wait_for_ci.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Pull workflow context into env vars so the prompt body never
+          # mixes ${{ }} interpolation with potentially adversarial data.
+          # None of these are attacker-controlled for the pull_request
+          # trigger, but using env: is a defense-in-depth standard.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          # OAuth token from `claude setup-token` -- billed against the user's
+          # Claude Max subscription, not API credits.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Invoke the project-local /review slash command. The command reads
+          # the PR diff, spawns specialized subagents, and posts inline
+          # review comments plus a top-level summary.
+          prompt: |
+            /review
+
+            Repository: ${{ env.REPO_FULL_NAME }}
+            Pull request: #${{ env.PR_NUMBER }}
+            Base ref: ${{ env.PR_BASE_REF }}
+            Head SHA: ${{ env.PR_HEAD_SHA }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,48 +30,50 @@ jobs:
 
       - name: Wait for other PR checks to complete
         id: wait_for_ci
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_FULL_NAME: ${{ github.repository }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # Excluded from the wait-and-pass check (this job's own check name).
-          SELF_CHECK_NAME: 'Claude code review'
-        run: |
-          set -euo pipefail
+        # Uses actions/github-script (the established pattern in this repo --
+        # see release-sonos-advanced.yml) instead of the gh CLI, which is not
+        # installed on the self-hosted runner. github-script bundles its own
+        # Node runtime + Octokit, so it has no runner-side dependencies.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const SELF_CHECK_NAME = 'Claude code review';
+            const PASS_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
+            const sha = context.payload.pull_request.head.sha;
+            const { owner, repo } = context.repo;
 
-          # Let GitHub queue any other PR-triggered workflows before polling.
-          # When a PR is opened, multiple workflows schedule in parallel; if we
-          # poll immediately we can race past checks that haven't registered yet.
-          echo "Waiting 60s for other workflows to register..."
-          sleep 60
+            // Let GitHub queue any other PR-triggered workflows before polling.
+            // When a PR is opened multiple workflows schedule in parallel; an
+            // immediate poll can race past checks that haven't registered yet.
+            core.info('Waiting 60s for other workflows to register...');
+            await new Promise(r => setTimeout(r, 60_000));
 
-          api_url="repos/$REPO_FULL_NAME/commits/$PR_HEAD_SHA/check-runs?per_page=100"
+            // Poll until every non-self check reaches a terminal state. The
+            // job-level timeout-minutes (25) bounds the total wait.
+            let others = [];
+            while (true) {
+              const all = await github.paginate(github.rest.checks.listForRef, {
+                owner, repo, ref: sha, per_page: 100,
+              });
+              others = all.filter(c => c.name !== SELF_CHECK_NAME);
+              const inFlight = others.filter(c => c.status !== 'completed');
+              if (inFlight.length === 0) break;
+              core.info(`Waiting on ${inFlight.length} other check(s)...`);
+              await new Promise(r => setTimeout(r, 30_000));
+            }
 
-          # Poll until every non-self check reaches a terminal state. The
-          # job-level timeout-minutes (25) bounds the total wait.
-          while :; do
-            data=$(gh api "$api_url")
-            in_flight=$(echo "$data" | jq --arg self "$SELF_CHECK_NAME" \
-              '[.check_runs[] | select(.name != $self and (.status == "queued" or .status == "in_progress"))] | length')
-            [ "$in_flight" = "0" ] && break
-            echo "Waiting on $in_flight other check(s)..."
-            sleep 30
-          done
-
-          # All other checks are done -- did any not pass? Treat success,
-          # skipped, and neutral as passing; everything else (failure, cancelled,
-          # timed_out, action_required, stale) blocks the review.
-          failed=$(echo "$data" | jq --arg self "$SELF_CHECK_NAME" \
-            '[.check_runs[] | select(.name != $self and .conclusion != null and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
-
-          if [ "$failed" != "0" ]; then
-            echo "::warning::$failed other check(s) did not pass; skipping Claude review."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "All other checks passed; proceeding with Claude review."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+            // All non-self checks completed. Treat success / skipped / neutral
+            // as passing; anything else (failure, cancelled, timed_out,
+            // action_required, stale) blocks the review.
+            const failed = others.filter(c => c.conclusion && !PASS_CONCLUSIONS.has(c.conclusion));
+            if (failed.length > 0) {
+              const names = failed.map(c => `${c.name} (${c.conclusion})`).join(', ');
+              core.warning(`${failed.length} other check(s) did not pass: ${names}; skipping Claude review.`);
+              core.setOutput('skip', 'true');
+            } else {
+              core.info('All other checks passed; proceeding with Claude review.');
+              core.setOutput('skip', 'false');
+            }
 
       - name: Run Claude review
         if: steps.wait_for_ci.outputs.skip != 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,60 @@
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Hoist user-content references into env: vars so the @claude trigger
+    # check (and any future logic) reads them via the env context. This is
+    # purely defensive -- contains() in an if: expression is evaluated by
+    # the GitHub expression engine and never reaches a shell -- but it
+    # keeps potentially-adversarial values in a single declaration site.
+    env:
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      REVIEW_BODY: ${{ github.event.review.body }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+    if: |
+      (github.event_name == 'issue_comment' && contains(env.COMMENT_BODY, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(env.COMMENT_BODY, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(env.REVIEW_BODY, '@claude')) ||
+      (github.event_name == 'issues' && (contains(env.ISSUE_BODY, '@claude') || contains(env.ISSUE_TITLE, '@claude')))
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This is an optional setting that allows Claude to read CI results on PRs.
+          additional_permissions: |
+            actions: read
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will
+          # perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration.
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options.
+          # claude_args: '--allowed-tools Bash(gh pr *)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,21 +14,17 @@ on:
 
 jobs:
   claude:
-    # Hoist user-content references into env: vars so the @claude trigger
-    # check (and any future logic) reads them via the env context. This is
-    # purely defensive -- contains() in an if: expression is evaluated by
-    # the GitHub expression engine and never reaches a shell -- but it
-    # keeps potentially-adversarial values in a single declaration site.
-    env:
-      COMMENT_BODY: ${{ github.event.comment.body }}
-      REVIEW_BODY: ${{ github.event.review.body }}
-      ISSUE_BODY: ${{ github.event.issue.body }}
-      ISSUE_TITLE: ${{ github.event.issue.title }}
+    # The env context is NOT available in job-level if: per GitHub Actions
+    # context-availability rules, so we reference github.event.* directly.
+    # contains() in an if: expression is evaluated by GitHub's expression
+    # engine -- it never reaches a shell, so the user-controlled body/title
+    # values cannot cause injection. The expression engine treats them as
+    # opaque strings for substring search.
     if: |
-      (github.event_name == 'issue_comment' && contains(env.COMMENT_BODY, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(env.COMMENT_BODY, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(env.REVIEW_BODY, '@claude')) ||
-      (github.event_name == 'issues' && (contains(env.ISSUE_BODY, '@claude') || contains(env.ISSUE_TITLE, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: self-hosted
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Adds three new GitHub Actions workflows and a Hubitat-tailored `/review` slash command, mirroring the setup that's been working well in the `letsbefire` repo.

- **`claude-review.yml`** — runs the project-local `/review` command on every PR, but **only after all other check-runs on the head SHA reach a passing terminal state**. If any other check fails, the review is skipped entirely so we don't waste Claude tokens reviewing a broken PR. A 60s initial sleep gives parallel-scheduled workflows time to register before polling begins; the job-level `timeout-minutes: 25` bounds the total wait.
- **`claude.yml`** — reactive workflow for `@claude` mentions in PR/issue/review/comment bodies. Verbatim from `letsbefire` (already domain-agnostic).
- **`claude-fix-on-failure.yml`** — listens for completions of the 5 non-Claude workflows (bundle + release). On `conclusion == 'failure'`, opens a GitHub issue mentioning `@claude` with full failure context, which then triggers `claude.yml` to attempt a fix. Title-based dedup (`[CI failure] {workflow} on {branch}`) appends a comment to an existing open issue rather than creating duplicates — this is the primary loop-prevention mechanism if Claude's fix introduces a second failure.
- **`.claude/commands/review.md`** — Hubitat-specific review specification with three subagents (correctness / quality / security) and an 80%+ confidence filter. Codifies the platform gotchas already documented in `CLAUDE.md` and the project's auto-memory: `#include` removal without restoring `import groovy.transform.Field` and other type imports, `pauseExecution()` blocking calls, `null` attribute values, lifecycle hook preservation, `dwinks` namespace, hand-edits to auto-generated `Bundles/`.

## Why

Currently every PR merges with no automated code review of the source files (the existing 5 workflows are all release/bundle automation that fires on push to `main`). This wires up automatic review feedback on opened/synchronized PRs and an auto-remediation loop for CI failures of the bundle and release workflows.

## Reviewer notes

- **`CLAUDE_CODE_OAUTH_TOKEN` is already configured** on this repo (verified via `gh secret list`). No secret setup is needed before merge.
- **The wait step is currently a 60s no-op** because no PR-triggered CI exists yet. The wait gate activates automatically the moment any PR-triggered workflow is added later — no further changes needed.
- **Workflows that could create a recursion loop are explicitly excluded** from `claude-fix-on-failure.yml`'s trigger filter: `Claude PR Review`, `Claude Code`, and the auto-issue workflow itself.
- **Defense-in-depth env: pattern**: all `${{ github.event.* }}` interpolations are hoisted into job-level `env:` blocks rather than embedded directly in shell `run:` steps or `if:` expressions. None of the values being interpolated are attacker-controlled in these triggers, but the env-only convention keeps the files audit-friendly.
- **YAML syntax validated** with PyYAML for all three workflow files; the wait step's polling logic was hand-traced for the no-other-CI case (exits the loop immediately on first poll).

## Test plan

- [ ] Open a tiny throwaway PR (e.g., comment-only change to a driver). Verify:
  - [ ] The `Claude PR Review` workflow run appears under Actions
  - [ ] After ~60s, the wait step logs `"All other checks passed; proceeding with Claude review."`
  - [ ] An inline comment or `"No blocking issues found."` summary comment is posted on the PR
- [ ] On the same PR, comment `@claude what does this file do?` and confirm the `Claude Code` workflow fires and replies.
- [ ] Negative test (correctness rules): push a deliberate `pauseExecution(1000)` or `#include` removal without restoring imports. Confirm the review flags it as `block`-severity.
- [ ] Negative test (auto-fix loop, after merge to main): push a deliberate Groovy syntax error to a file that triggers a bundle workflow. Confirm:
  - [ ] An issue titled `[CI failure] Create … Bundle on main` is opened automatically
  - [ ] The issue body contains `@claude please investigate and fix this CI failure.`
  - [ ] The `Claude Code` workflow fires off the issue and attempts a fix
- [ ] Dedup test: deliberately re-trigger the same failure. Confirm a comment is added to the existing issue rather than creating a duplicate.